### PR TITLE
chore: Configure Vercel preview deployments for contributors

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,15 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "regions": ["iad1"],
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "feature/*": true,
+      "fix/*": true,
+      "chore/*": true,
+      "refactor/*": true
+    }
+  },
   "env": {
     "NODE_ENV": "production"
   },


### PR DESCRIPTION
## Summary
Enable preview deployments for open source contributors submitting PRs from forks.

## Related Issues
Closes #108

## Changes
- Add git deployment settings in vercel.json for branch patterns:
  - `main` - production
  - `feature/*`, `fix/*`, `chore/*`, `refactor/*` - preview deployments

## Test plan
- [ ] Verify vercel.json is valid
- [ ] Merge and enable fork previews in dashboard
- [ ] Test with a PR from a fork