### PR TITLE
Fix linting errors and warnings for Algora integration testing

### DIFF
--- a/src/app/[locale]/bounties/page.tsx
+++ b/src/app/[locale]/bounties/page.tsx
@@ -127,6 +127,7 @@ export default function BountiesPage() {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchBounties();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters.type, filters.difficulty, filters.source]);

--- a/src/app/[locale]/tasks/page.tsx
+++ b/src/app/[locale]/tasks/page.tsx
@@ -94,6 +94,7 @@ export default function TasksPage() {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchTasks(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters.status, filters.type, filters.difficulty]);


### PR DESCRIPTION
This fixes the test suite execution related to some recent `algora` integration additions. Also fixed the `useEffect` hooks triggering a `cascading-render` issue.