### PR TITLE
docs: clarify bounty disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# DISCLAIMER since multiple people have asked **We do not do bounty at the moment**
+# Disclaimer
+
+**We do not offer bounties at the moment.**
 
 # ClawFreelance
 


### PR DESCRIPTION
Clarifies the top README disclaimer so readers can immediately tell that ClawFreelance is not currently offering bounties.

Safety: README-only change made through the GitHub API. No clone, dependency install, or code execution.